### PR TITLE
Bump to v0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,12 @@ It can be added to your remark plugins in `gatsby-config.js` like so:
               title: 'anti/pattern', // website title
               separator: '|', // default
               author: 'alessia bellisario',
-              background: require.resolve('./content/assets/base.png') // defaults to black
-              fontColor: '#228B22', // defaults to white
+              background: require.resolve('./content/assets/base.png') // path to 1200x630px file or hex code, defaults to black (#000000)
+              fontColor: '#228B22', // defaults to white (#ffffff)
               titleFontSize: 96, // default
               subtitleFontSize: 60, // default
               fontStyle: 'monospace', // default
+              fontFile: require.resolve('./assets/fonts/someFont.ttf') // will override fontStyle - path to custom TTF font
             },
           },
         ],
@@ -46,6 +47,7 @@ It can be added to your remark plugins in `gatsby-config.js` like so:
 | `titleFontSize`    | ❌       | int                                                | `96`          |
 | `subtitleFontSize` | ❌       | int                                                | `60`          |
 | `fontStyle`        | ❌       | "monospace" or "sans-serif"                        | `monospace`   |
+| `fontFile`         | ❌       | path to TTF font file                              | ❌            |
 
 The images will be saved in your site's `/public` folder, and the link to your `twitter:image` should be an absolute URL (something like `${siteUrl}${blogPostSlug}twitter-card.jpg`) E.g. for [this blog post](https://aless.co/how-to-build-a-keyboard/) the generated image can be found at the link [https://aless.co/how-to-build-a-keyboard/twitter-card.jpg](https://aless.co/how-to-build-a-keyboard/twitter-card.jpg).
 
@@ -53,10 +55,10 @@ Further instructions on how to include open graph images in the metadata of your
 
 ## Roadmap
 
-- [ ] Custom OTF/TTF fonts
+- [x] Custom TTF fonts 🎉
 - [x] Monospace or sans serif font
 - [x] Custom title font size
 - [x] Custom subtitle font size
 - [x] Custom font color
 - [x] Accept path to background image
-- [x] Solid color card background
+- [x] OR solid color background with hex code

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-remark-twitter-cards",
-  "version": "0.1.0-alpha2",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -6459,9 +6459,9 @@
       }
     },
     "wasm-twitter-card": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/wasm-twitter-card/-/wasm-twitter-card-0.2.0.tgz",
-      "integrity": "sha512-4WIKypB35QlWidcY1kJH1zSV0Ig8BVoiErZ34DkriEUGXzFkRCCiQwDxffGjyEFMHC9RdSL73HLPvdJyn3/zjQ=="
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/wasm-twitter-card/-/wasm-twitter-card-0.3.0.tgz",
+      "integrity": "sha512-S5wPvSJclw/JOqw3XQyP1S7a+KMjL6O42jy0wBIzKZ7x/Yz9/Ou4Itd2TgExGkZ90dd7MhzYsMNC/UxoctVLUw=="
     },
     "which": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-remark-twitter-cards",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Gatsby Remark plugin for generating Twitter Open Graph cards",
   "repository": "https://github.com/alessbell/gatsby-remark-twitter-cards",
   "author": "Alessia Bellisario",
@@ -31,7 +31,7 @@
   "dependencies": {
     "jimp": "0.6.4",
     "path": "0.12.7",
-    "wasm-twitter-card": "0.2.0"
+    "wasm-twitter-card": "0.3.0"
   },
   "devDependencies": {
     "babel-cli": "6.26.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
+/*eslint-env node*/
+const fs = require("fs");
 const path = require("path");
 const Jimp = require("jimp");
 const twitterCard = require("wasm-twitter-card");
@@ -46,6 +48,7 @@ module.exports = (
     subtitleFontSize = 60,
     fontStyle = "monospace",
     separator = "|",
+    fontFile,
   }
 ) => {
   const post = markdownNode.frontmatter;
@@ -65,13 +68,22 @@ module.exports = (
       title && author ? `${title} ${separator} ${author}` : title || author;
   }
 
+  const fontToUint8Array = fontFile
+    ? fs.readFileSync(require.resolve(fontFile), null)
+    : new Uint8Array();
+
+  if (fontFile) {
+    fontStyle = "custom";
+  }
+
   const buffer = twitterCard.generate_text(
     post.title,
     formattedDetails,
     titleFontSize,
     subtitleFontSize,
     hexToRgb(fontColor),
-    fontStyle !== "monospace"
+    fontStyle,
+    fontToUint8Array
   );
 
   return Promise.all([generateBackground(background), writeTextToCard(buffer)])


### PR DESCRIPTION
Uses v0.3.0 of `wasm-twitter-card` to accept a file path to a TTF font. Using a new Rust lib for font layout under the hood which also fixes some text layout issues in certain cases.