### PR TITLE
Add useFrontmatterSlug option to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ It can be added to your remark plugins in `gatsby-config.js` like so:
               subtitleFontSize: 60, // default
               fontStyle: 'monospace', // default
               fontFile: require.resolve('./assets/fonts/someFont.ttf') // will override fontStyle - path to custom TTF font
+              useFrontmatterSlug: false // default, if true it will use the slug defined in the post frontmatter
             },
           },
         ],

--- a/src/index.js
+++ b/src/index.js
@@ -49,6 +49,7 @@ module.exports = (
     fontStyle = "monospace",
     separator = "|",
     fontFile,
+    useFrontmatterSlug = false,
   }
 ) => {
   const post = markdownNode.frontmatter;
@@ -56,11 +57,8 @@ module.exports = (
   validateFontSize(titleFontSize, "titleFontSize");
   validateFontSize(subtitleFontSize, "subtitleFontSize");
 
-  const output = path.join(
-    "./public",
-    markdownNode.fields.slug,
-    "twitter-card.jpg"
-  );
+  const slug = useFrontmatterSlug ? post.slug : markdownNode.fields.slug;
+  const output = path.join("./public", slug, "twitter-card.jpg");
 
   let formattedDetails = "";
   if (title || author) {
@@ -88,11 +86,11 @@ module.exports = (
 
   return Promise.all([generateBackground(background), writeTextToCard(buffer)])
     .then(([base, text]) => base.composite(text, 0, 0))
-    .then(image =>
+    .then((image) =>
       image
         .writeAsync(output)
         .then(() => console.log("Generated Twitter Card: ", output))
-        .catch(err => err)
+        .catch((err) => err)
     )
     .catch(console.error);
 };


### PR DESCRIPTION
Thank you for this great plugin! I have added an option to use the slug defined in the post frontmatter instead of the markdown slug, since in my case, my slugs are different than the markdown files/folders where the content is.